### PR TITLE
Fix for issue #8 ("Display x times in K2 extra fields section")

### DIFF
--- a/itpshare.php
+++ b/itpshare.php
@@ -45,7 +45,7 @@ class plgContentITPShare extends JPlugin {
 	 */
     public function onContentPrepare($context, &$article, &$params, $page = 0) {
 
-        if (!$article OR !isset($this->params)) { return; };            
+        if (!$article OR ($article AND !property_exists($article, 'id')) OR !isset($this->params)) { return; };            
         
         $app = JFactory::getApplication();
         /** @var $app JSite **/


### PR DESCRIPTION
See issue #8

The problem here is that "onContentPrepare" gets called for every extra field.
However, since extra fields objects lack an "id" property they can be easily filtered out.
